### PR TITLE
fix: Use our own exponential backoff implementation which is using Go 1.23 iterators

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ toolchain go1.23.4
 
 require (
 	dario.cat/mergo v1.0.1
-	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cilium/ebpf v0.17.1
 	github.com/fsnotify/fsnotify v1.8.0
 	github.com/google/nftables v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,6 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
-github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
-github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=

--- a/pkg/backoff/backoff.go
+++ b/pkg/backoff/backoff.go
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2024 Steffen Vogel <post@steffenvogel.de>
+// SPDX-License-Identifier: Apache-2.0
+
+package backoff
+
+import (
+	"fmt"
+	"iter"
+	"time"
+)
+
+// stop indicates that no more retries should be made for use in NextBackOff().
+const stop time.Duration = -1
+
+func Retry(b *ExponentialBackOff) iter.Seq2[int, time.Duration] {
+	return func(yield func(int, time.Duration) bool) {
+		b.Reset()
+
+		for i := 0; ; i++ {
+			if !yield(i, b.GetElapsedTime()) {
+				break
+			}
+
+			next := b.NextBackOff()
+			fmt.Println(next)
+			if next == stop {
+				break
+			}
+
+			b.Clock.Sleep(next)
+		}
+	}
+}

--- a/pkg/backoff/backoff_test.go
+++ b/pkg/backoff/backoff_test.go
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: 2024 Steffen Vogel <post@steffenvogel.de>
+// SPDX-License-Identifier: Apache-2.0
+
+package backoff_test
+
+import (
+	"testing"
+	"time"
+
+	"cunicu.li/cunicu/pkg/backoff"
+	"cunicu.li/cunicu/test"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type mockClock struct {
+	now time.Time
+}
+
+func (c *mockClock) Sleep(d time.Duration) {
+	c.now = c.now.Add(d)
+}
+
+func (c *mockClock) Now() time.Time {
+	return c.now
+}
+
+func TestSuite(t *testing.T) {
+	test.SetupLogging()
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Backoff Suite")
+}
+
+var _ = Context("Backoff", func() {
+	var (
+		b = &backoff.ExponentialBackOff{
+			InitialInterval:     100 * time.Millisecond,
+			RandomizationFactor: 0.1,
+			Multiplier:          3,
+			MaxInterval:         10 * time.Second,
+			MaxElapsedTime:      25 * time.Second,
+
+			Clock: &mockClock{},
+		}
+
+		expectedResults = []time.Duration{
+			100 * time.Millisecond,
+			300 * time.Millisecond,
+			900 * time.Millisecond,
+			2700 * time.Millisecond,
+			8100 * time.Millisecond,
+			10000 * time.Millisecond,
+			10000 * time.Millisecond,
+			10000 * time.Millisecond,
+			10000 * time.Millisecond,
+		}
+	)
+
+	It("produces exponentially increasing backoff durations", func() {
+		b.Reset()
+
+		for _, expected := range expectedResults {
+			// Assert that the next backoff falls in the expected range.
+			Expect(b.CurrentInterval).To(BeNumerically("==", expected))
+
+			minInterval := expected - time.Duration(b.RandomizationFactor*float64(expected))
+			maxInterval := expected + time.Duration(b.RandomizationFactor*float64(expected))
+
+			actualInterval := b.NextBackOff()
+			Expect(actualInterval).To(BeNumerically(">=", minInterval))
+			Expect(actualInterval).To(BeNumerically("<=", maxInterval))
+		}
+	})
+
+	It("is a Go 1.23 iterator", func() {
+		for i := range backoff.Retry(b) {
+			expected := expectedResults[i]
+
+			Expect(b.CurrentInterval).To(BeNumerically("==", expected))
+		}
+	})
+})

--- a/pkg/backoff/clock.go
+++ b/pkg/backoff/clock.go
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2024 Steffen Vogel <post@steffenvogel.de>
+// SPDX-License-Identifier: Apache-2.0
+
+package backoff
+
+import "time"
+
+type Clock interface {
+	Sleep(time.Duration)
+	Now() time.Time
+}
+
+type systemClock struct{}
+
+func (c *systemClock) Sleep(d time.Duration) {
+	time.Sleep(d)
+}
+
+func (c *systemClock) Now() time.Time {
+	return time.Now()
+}

--- a/pkg/backoff/exponential.go
+++ b/pkg/backoff/exponential.go
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: 2024 Steffen Vogel <post@steffenvogel.de>
+// SPDX-License-Identifier: Apache-2.0
+
+package backoff
+
+import (
+	"time"
+
+	"cunicu.li/cunicu/pkg/crypto"
+)
+
+/*
+ExponentialBackOff is a backoff implementation that increases the backoff
+period for each retry attempt using a randomization function that grows exponentially.
+
+NextBackOff() is calculated using the following formula:
+
+	randomized interval =
+	    RetryInterval * (random value in range [1 - RandomizationFactor, 1 + RandomizationFactor])
+
+In other words NextBackOff() will range between the randomization factor
+percentage below and above the retry interval.
+
+For example, given the following parameters:
+
+	RetryInterval = 2
+	RandomizationFactor = 0.5
+	Multiplier = 2
+
+the actual backoff period used in the next retry attempt will range between 1 and 3 seconds,
+multiplied by the exponential, that is, between 2 and 6 seconds.
+
+Note: MaxInterval caps the RetryInterval and not the randomized interval.
+
+If the time elapsed since an ExponentialBackOff instance is created goes past the
+MaxElapsedTime, then the method NextBackOff() starts returning backoff.Stop.
+
+The elapsed time can be reset by calling Reset().
+
+Example: Given the following default arguments, for 10 tries the sequence will be,
+and assuming we go over the MaxElapsedTime on the 10th try:
+
+	Request #  RetryInterval (seconds)  Randomized Interval (seconds)
+
+	 1          0.5                     [0.25,   0.75]
+	 2          0.75                    [0.375,  1.125]
+	 3          1.125                   [0.562,  1.687]
+	 4          1.687                   [0.8435, 2.53]
+	 5          2.53                    [1.265,  3.795]
+	 6          3.795                   [1.897,  5.692]
+	 7          5.692                   [2.846,  8.538]
+	 8          8.538                   [4.269, 12.807]
+	 9         12.807                   [6.403, 19.210]
+	10         19.210                   backoff.Stop
+
+Note: Implementation is not thread-safe.
+*/
+type ExponentialBackOff struct {
+	InitialInterval     time.Duration
+	RandomizationFactor float64
+	Multiplier          float64
+	MaxInterval         time.Duration
+	// After MaxElapsedTime the ExponentialBackOff returns Stop.
+	// It never stops if MaxElapsedTime == 0.
+	MaxElapsedTime time.Duration
+
+	CurrentInterval time.Duration
+	StartTime       time.Time
+
+	Clock Clock
+}
+
+// Reset the interval back to the initial retry interval and restarts the timer.
+// Reset must be called before using b.
+func (b *ExponentialBackOff) Reset() {
+	if b.Clock == nil {
+		b.Clock = &systemClock{}
+	}
+
+	b.CurrentInterval = b.InitialInterval
+	b.StartTime = b.Clock.Now()
+}
+
+// NextBackOff calculates the next backoff interval using the formula:
+//
+//	Randomized interval = RetryInterval * (1 ± RandomizationFactor)
+func (b *ExponentialBackOff) NextBackOff() time.Duration {
+	// Make sure we have not gone over the maximum elapsed time.
+	elapsed := b.GetElapsedTime()
+	next := crypto.GetRandomValueFromInterval(b.RandomizationFactor, b.CurrentInterval)
+	b.incrementCurrentInterval()
+
+	if b.MaxElapsedTime != 0 && elapsed+next > b.MaxElapsedTime {
+		return stop
+	}
+
+	return next
+}
+
+// GetElapsedTime returns the elapsed time since an ExponentialBackOff instance
+// is created and is reset when Reset() is called.
+//
+// The elapsed time is computed using time.Now().UnixNano(). It is
+// safe to call even while the backoff policy is used by a running
+// ticker.
+func (b *ExponentialBackOff) GetElapsedTime() time.Duration {
+	return b.Clock.Now().Sub(b.StartTime)
+}
+
+// Increments the current interval by multiplying it with the multiplier.
+func (b *ExponentialBackOff) incrementCurrentInterval() {
+	// Check for overflow, if overflow is detected set the current interval to the max interval.
+	if float64(b.CurrentInterval) >= float64(b.MaxInterval)/b.Multiplier {
+		b.CurrentInterval = b.MaxInterval
+	} else {
+		b.CurrentInterval = time.Duration(float64(b.CurrentInterval) * b.Multiplier)
+	}
+}

--- a/pkg/crypto/crypto.go
+++ b/pkg/crypto/crypto.go
@@ -9,6 +9,23 @@ import (
 	"math/big"
 )
 
+// Intn is a shortcut for generating a random integer between 0 and
+// max using crypto/rand.
+func Intn(maxi int64) int64 {
+	nBig, err := rand.Int(rand.Reader, big.NewInt(maxi))
+	if err != nil {
+		panic(err)
+	}
+
+	return nBig.Int64()
+}
+
+// Float64 is a shortcut for generating a random float between 0 and
+// 1 using crypto/rand.
+func Float64() float64 {
+	return float64(Intn(1<<53)) / (1 << 53)
+}
+
 func GetNonce(length int) (Nonce, error) {
 	nonce := make(Nonce, length)
 
@@ -18,6 +35,25 @@ func GetNonce(length int) (Nonce, error) {
 	}
 
 	return nonce, nil
+}
+
+// Returns a random value from the following interval:
+//
+//	[currentInterval - randomizationFactor * currentInterval, currentInterval + randomizationFactor * currentInterval].
+func GetRandomValueFromInterval[V ~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr | float32 | float64](randomizationFactor float64, currentInterval V) V {
+	if randomizationFactor == 0 {
+		return currentInterval // Make sure no randomness is used when randomizationFactor is 0.
+	}
+
+	delta := randomizationFactor * float64(currentInterval)
+
+	minInterval := float64(currentInterval) - delta
+	maxInterval := float64(currentInterval) + delta
+
+	// Get a random value from the range [minInterval, maxInterval].
+	// The formula used below has a +1 because if the minInterval is 1 and the maxInterval is 3 then
+	// we want a 33% chance for selecting either 1, 2 or 3.
+	return V(minInterval + (Float64() * (maxInterval - minInterval + 1)))
 }
 
 // GetRandomString generates a random string for cryptographic usage.


### PR DESCRIPTION
And it allows us to drop an external dependency as well