### PR TITLE
fix(nix): Use local Nixpkgs in overlay

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,11 +24,18 @@
         };
 
         overlays = {
-          default = final: prev: {
-            cunicu = final.callPackage ./nix/cunicu.nix { };
-            cunicu-website = final.callPackage ./nix/website.nix { };
-            cunicu-scripts = final.callPackage ./nix/scripts.nix { };
-            gocov-merger = final.callPackage ./nix/gocov-merger.nix { };
+          default = final: prev:
+          let
+            pkgs = import inputs.nixpkgs {
+              inherit (final) system;
+              overlays = [ self.overlays.default ];
+            };
+          in
+          {
+            cunicu = pkgs.callPackage ./nix/cunicu.nix { };
+            cunicu-website = pkgs.callPackage ./nix/website.nix { };
+            cunicu-scripts = pkgs.callPackage ./nix/scripts.nix { };
+            gocov-merger = pkgs.callPackage ./nix/gocov-merger.nix { };
           };
         };
       };


### PR DESCRIPTION
The local `nixpkgs` input should be used in the overlays, otherwise it will not properly track what is used in the local flake when `cunicu.nixpkgs.follows = xxx` is not used when using this repo as a flake input.

I noticed this when using this flake because `buildGo124Module` is only in unstable, but I am using `nixos-24.11` in my flake.