### PR TITLE
fix(epdisc): exit create agent loop on success

### DIFF
--- a/pkg/daemon/feature/epdisc/peer.go
+++ b/pkg/daemon/feature/epdisc/peer.go
@@ -307,6 +307,8 @@ func (p *Peer) createAgentWithBackoff() {
 			p.logger.Error("Failed to create agent",
 				zap.Error(err),
 				zap.Duration("after", d))
+		} else {
+			break
 		}
 	}
 }


### PR DESCRIPTION
I noticed the logs below even after successful connection between peers. I believe the intention was to exit the loop once an agent has been created successfully.

```
22:13:42.878391 error epdisc.peer       Failed to create agent  intf=wg0 peer=8Xud0OxvafbldGpJmswo3BKf6SXO6a0yHv50TCR+DmI= error='failed to create new agent if previous one is not closed' after=1.133670669s
22:13:42.901595 error epdisc.peer       Failed to create agent  intf=wg0 peer=iE8P0Xat/i/uJS8ZpssaxGvx61uv4Tq+3hSoFyA06As= error='failed to create new agent if previous one is not closed' after=1.160326338s
22:13:42.958785 error epdisc.peer       Failed to create agent  intf=wg0 peer=9hzJgp4suIt8kqEexbZtP+Yh4TfDZmuhIe8aGbYLIAo= error='failed to create new agent if previous one is not closed' after=1.221541092s
22:13:43.617502 error epdisc.peer       Failed to create agent  intf=wg0 peer=iE8P0Xat/i/uJS8ZpssaxGvx61uv4Tq+3hSoFyA06As= error='failed to create new agent if previous one is not closed' after=1.876232976s
22:13:43.787730 error epdisc.peer       Failed to create agent  intf=wg0 peer=9hzJgp4suIt8kqEexbZtP+Yh4TfDZmuhIe8aGbYLIAo= error='failed to create new agent if previous one is not closed' after=2.050485488s
22:13:44.046112 error epdisc.peer       Failed to create agent  intf=wg0 peer=8Xud0OxvafbldGpJmswo3BKf6SXO6a0yHv50TCR+DmI= error='failed to create new agent if previous one is not closed' after=2.301390966s
22:13:44.097224 error epdisc.peer       Failed to create agent  intf=wg0 peer=N55hPe3/CbXYzxlJBbvfWlrgkNmpX9KJMSJzL+0KC18= error='failed to create new agent if previous one is not closed' after=2.357815471s
22:13:44.202471 error epdisc.peer       Failed to create agent  intf=wg0 peer=mg7BDf6VOzdVv97KRJBUGygwFPGZp6+ugacPFw+c/Eo= error='failed to create new agent if previous one is not closed' after=2.459455478s
22:13:44.735845 error epdisc.peer       Failed to create agent  intf=wg0 peer=iE8P0Xat/i/uJS8ZpssaxGvx61uv4Tq+3hSoFyA06As= error='failed to create new agent if previous one is not closed' after=2.994575811s
22:13:45.480653 error epdisc.peer       Failed to create agent  intf=wg0 peer=mg7BDf6VOzdVv97KRJBUGygwFPGZp6+ugacPFw+c/Eo= error='failed to create new agent if previous one is not closed' after=3.7376377s
22:13:45.483826 error epdisc.peer       Failed to create agent  intf=wg0 peer=N55hPe3/CbXYzxlJBbvfWlrgkNmpX9KJMSJzL+0KC18= error='failed to create new agent if previous one is not closed' after=3.744416951s
22:13:46.147906 error epdisc.peer       Failed to create agent  intf=wg0 peer=9hzJgp4suIt8kqEexbZtP+Yh4TfDZmuhIe8aGbYLIAo= error='failed to create new agent if previous one is not closed' after=4.410662001s
22:13:46.566350 error epdisc.peer       Failed to create agent  intf=wg0 peer=8Xud0OxvafbldGpJmswo3BKf6SXO6a0yHv50TCR+DmI= error='failed to create new agent if previous one is not closed' after=4.821629116s
22:13:46.660591 error epdisc.peer       Failed to create agent  intf=wg0 peer=iE8P0Xat/i/uJS8ZpssaxGvx61uv4Tq+3hSoFyA06As= error='failed to create new agent if previous one is not closed' after=4.919322123s
22:13:48.141994 error epdisc.peer       Failed to create agent  intf=wg0 peer=N55hPe3/CbXYzxlJBbvfWlrgkNmpX9KJMSJzL+0KC18= error='failed to create new agent if previous one is not closed' after=6.402584777s
```